### PR TITLE
Fixed missing param in MediaSource.isTypeSupported

### DIFF
--- a/src/Fable.Extras/Media.fs
+++ b/src/Fable.Extras/Media.fs
@@ -276,9 +276,20 @@ module JSe =
 
         /// Indicates if the given MIME type is supported by the current user agent — this is, 
         /// if it can successfully create SourceBuffer objects for that MIME type.
-        [<Emit("MediaSource.isTypeSupported()")>]
+        [<Emit("MediaSource.isTypeSupported($0)")>]
         let inline isTypeSupported (mimeType: string) : bool = jsNative
 
         /// Checks if the browser supports MediaSource.
         [<Emit("'MediaSource' in window")>]
         let inline isMediaSourceSupported () : bool = jsNative
+        
+    [<Erase;RequireQualifiedAccess>]
+    module MediaRecorder =
+
+        /// A static method which returns a true or false value indicating if the given MIME media type is supported by the current user agent.
+        [<Emit("MediaRecorder.isTypeSupported($0)")>]
+        let inline isTypeSupported (mimeType: string) : bool = jsNative
+
+        /// Checks if the browser supports MediaRecorder.
+        [<Emit("'MediaRecorder' in window")>]
+        let inline isMediaRecorderSupported () : bool = jsNative


### PR DESCRIPTION
Also added an initial binding for the MediaRecorder

<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
MediaSource.isSupportedType doesn't pass through the mime type

## What is the new behavior?
Fixed the above issue.
Added an initial start of the MediaRecorder bindings

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
